### PR TITLE
Use .NET 6 to build

### DIFF
--- a/.github/workflows/build-fenixlib.yml
+++ b/.github/workflows/build-fenixlib.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore fenixlib/FenixLib
     - name: Build


### PR DESCRIPTION
## What

* Use .NET 6 SDK to build

## Why

* .NET 5 is no longer supported